### PR TITLE
fix(e2e): create custom typeText for the custom Editor

### DIFF
--- a/src/test.js
+++ b/src/test.js
@@ -1,15 +1,44 @@
-import {Selector} from 'testcafe'
+import {Selector, ClientFunction} from 'testcafe'
 
 fixture('ProseMirror repro').page('http://localhost:8080')
 
-test('empty editor without placeholder', t => {
+test('empty editor without placeholder', async t => {
   const selector = Selector('#plain div[contenteditable]')
-  return t.typeText(selector, 'Hello test')
-      .expect(selector.innerText).contains('Hello')
+  await t
+    .hover(selector)
+    .expect(selector.hasAttribute("disabled")).notOk({timeout: 5000})
+    .click(selector)
+    .typeText(selector, 'Hello test')
+    .pressKey("tab")
+    .expect(selector.innerText).contains('Hello');
 })
 
-test('empty editor with placeholder', t => {
-  const selector = Selector('#with-placeholder div[contenteditable]')
-  return t.typeText(selector, 'Hello test')
-      .expect(selector.innerText).contains('Hello')
+test('empty editor with placeholder', async t => {
+  const selector = Selector('#with-placeholder div[contenteditable]');
+  await t
+    .hover(selector)
+    .expect(selector.hasAttribute("disabled")).notOk({timeout: 5000})
+    .click(selector);
+   await typeTextInEditor(selector, "Hello World", t);
+   await t
+    .pressKey("tab")
+    .expect(selector.innerText).contains('Hello');
 })
+
+async function typeTextInEditor(selector, text, t) {
+  const input = selector.find("p");
+  await t.click(input);
+  [...text].forEach( async char => {
+    await sendKey(char, input);
+    await t.wait(100);
+  });
+  await t.click(input);
+}
+
+const sendKey = ClientFunction((key, selector) => {
+  return new Promise ( (resolve) => {
+    const element = selector();
+    element.innerText += key;
+    resolve();
+  });
+});


### PR DESCRIPTION
Hi @tamlyn , 
I created a custom typeText method for the second test and I have refactored your test sequence in order to simulate what a real user will do in the UI.
A real user do the following steps in order to edit a field:

1. hover over the field
2. wait until the field is clickable
3. click in the field to start typing
4. type text
5. go the next field by clicking on the TAB key
